### PR TITLE
Add EPAM Client Work visibility test

### DIFF
--- a/tests/epam-client-work.test.ts
+++ b/tests/epam-client-work.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM Client Work visibility test', async ({ page }) => {
+  // Open Chrome browser and navigate to EPAM website
+  await page.goto('https://www.epam.com/');
+
+  // Wait for the page to load and maximize the window
+  await page.waitForLoadState('networkidle');
+  await page.setViewportSize({ width: 1920, height: 1080 });
+
+  // Click on the "Services" text in the header menu
+  await page.click('text=Services');
+
+  // Wait for the page to change and click the "Explore Our Client Work" link
+  await page.waitForNavigation();
+  await page.click('text=Explore Our Client Work');
+
+  // Wait for the page to change and verify that the "Client Work" text is visible
+  await page.waitForNavigation();
+  await expect(page.locator('text=Client Work')).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds a new Playwright test script to verify the visibility of "Client Work" text on the EPAM website after navigating through specific pages.