### PR TITLE
Add EPAM Client Work visibility test

### DIFF
--- a/tests/epam-client-work.test.ts
+++ b/tests/epam-client-work.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM Client Work visibility test', async ({ page }) => {
+  // Navigate to EPAM website
+  await page.goto('https://www.epam.com/');
+  
+  // Maximize the window
+  await page.setViewportSize({ width: 1920, height: 1080 });
+
+  // Wait for the page to load
+  await page.waitForLoadState('networkidle');
+
+  // Click on the "Services" text in the header menu
+  await page.click('text=Services');
+
+  // Wait for the page to change
+  await page.waitForNavigation();
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Wait for the page to change
+  await page.waitForNavigation();
+
+  // Verify that the "Client Work" text is visible on the page
+  await expect(page.locator('text=Client Work')).toBeVisible();
+});


### PR DESCRIPTION
This PR adds a Playwright test to verify the visibility of "Client Work" text on EPAM website after navigating through Services and Explore Our Client Work pages.