### PR TITLE
Add EPAM Client Work visibility test

### DIFF
--- a/tests/epam-client-work.test.ts
+++ b/tests/epam-client-work.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM Client Work visibility test', async ({ page }) => {
+  // Navigate to EPAM website
+  await page.goto('https://www.epam.com/');
+
+  // Wait for the page to load and maximize the window
+  await page.waitForLoadState('networkidle');
+  await page.setViewportSize({ width: 1920, height: 1080 });
+
+  // Click on the "Services" text in the header menu
+  await page.click('text=Services');
+
+  // Wait for the page to change
+  await page.waitForNavigation();
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Wait for the page to change
+  await page.waitForNavigation();
+
+  // Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.locator('text=Client Work').first();
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
This PR adds a new Playwright test script to verify the visibility of "Client Work" text on the EPAM website after navigating through specific pages.