### PR TITLE
Add EPAM Client Work visibility test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,13 @@
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  use: {
+    headless: false,
+    viewport: { width: 1280, height: 720 },
+    ignoreHTTPSErrors: true,
+    video: 'on-first-retry',
+  },
+};
+
+export default config;

--- a/tests/epam-client-work.test.ts
+++ b/tests/epam-client-work.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM Client Work visibility test', async ({ page }) => {
+  // Navigate to EPAM website
+  await page.goto('https://www.epam.com/');
+
+  // Maximize the window
+  await page.setViewportSize({ width: 1920, height: 1080 });
+
+  // Wait for the page to load
+  await page.waitForLoadState('networkidle');
+
+  // Click on the "Services" text in the header menu
+  await page.click('text=Services');
+
+  // Wait for the page to change
+  await page.waitForNavigation();
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Wait for the page to change
+  await page.waitForNavigation();
+
+  // Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.locator('text=Client Work').first();
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds a Playwright test to verify the visibility of "Client Work" text on the EPAM website. The test navigates through the site, clicking on specific links, and checks for the presence of the required text.

Changes include:
- New test file: `tests/epam-client-work.test.ts`
- New Playwright configuration file: `playwright.config.ts`

To run the test:
1. Install dependencies: `npm install @playwright/test`
2. Install browsers: `npx playwright install`
3. Run the test: `npx playwright test`